### PR TITLE
Support for page titles as well

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   singlesearchresult
 author Matthias Schulte
 email  dokuwiki@lupo49.de
-date   2013-04-07
+date   2015-05-15
 name   singlesearchresult plugin
 desc   Redirects directly to found page when only one page is found
 url    https://www.dokuwiki.org/plugin:singlesearchresult


### PR DESCRIPTION
with these changes the plugin also checks the results returned from page title search, not only the ones for fulltext search. It's my first edit on a DokuWiki plugin and my first usage of GitHub, so please slap for anything I can improve in code and process